### PR TITLE
feat: setup repository as GitHub Action

### DIFF
--- a/.github/workflows/github-action-regression-test.yaml
+++ b/.github/workflows/github-action-regression-test.yaml
@@ -1,6 +1,6 @@
 on:
   workflow_dispatch:
-
+  
 jobs:
   run-action:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-action-regression-test.yaml
+++ b/.github/workflows/github-action-regression-test.yaml
@@ -1,0 +1,11 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  run-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          dryrun: true

--- a/.github/workflows/github-action-regression-test.yaml
+++ b/.github/workflows/github-action-regression-test.yaml
@@ -1,6 +1,6 @@
 on:
   workflow_dispatch:
-  
+
 jobs:
   run-action:
     runs-on: ubuntu-latest

--- a/action.yaml
+++ b/action.yaml
@@ -7,28 +7,22 @@ branding:
 inputs:
   token:
     description: Auth token
-    default: '${{ github.token }}'
+    default: ${{ github.token }}
   user:
     description: Username
-    default: '${{ github.repository_owner }}'
+    default: ${{ github.repository_owner }}
   repo:
     description: Repository name to push badges
   size:
-    description: 'Badge size for README.md, px'
+    description: Badge size for README.md, px
   dryrun:
-    description: 'Generate badges, but skip pushing them to git'
+    description: Generate badges, but skip pushing them to git
   omit:
-    description: >-
-      List of badges to exclude. For example, if you're too shy to flex your
-      stars: omit: stars-100,stars-500,stars-1000 or even shorter omit: stars-*
+    description: "List of badges to exclude. For example, if you're too shy to flex your stars: omit: stars-100,stars-500,stars-1000 or even shorter omit: stars-*"
   pick:
-    desciption: >-
-      list of badges to pick. Pass pick: a-commit,ab-commit,revert-revert-commit
-      to generate only the specified entries. If empty gets all of them
+    description: 'list of badges to pick. Pass pick: a-commit,ab-commit,revert-revert-commit to generate only the specified entries. If empty gets all of them'
   compact:
-    description: >-
-      Represent the highest tier badges in README.md. For example, If you have
-      both stars-100 and stars-500 achievements, only the last one will be shown
+    description: 'Represent the highest tier badges in README.md. For example, If you have both stars-100 and stars-500 achievements, only the last one will be shown'
 runs:
   using: composite
   steps:

--- a/action.yaml
+++ b/action.yaml
@@ -1,39 +1,45 @@
-name: 'My Badges'
-description: 'Generates My Badges'
-author: 'my-badges'
+name: My Badges
+description: Generates My Badges
+author: my-badges
 branding:
   icon: award
   color: blue
 inputs:
-  token: 
-     description: 'Auth token' 
-     default: ${{ github.token }}
+  token:
+    description: Auth token
+    default: '${{ github.token }}'
   user:
-    description: 'Username' 
-    default: ${{ github.repository_owner }}
+    description: Username
+    default: '${{ github.repository_owner }}'
   repo:
-    description: 'Repository name to push badges' 
+    description: Repository name to push badges
   size:
     description: 'Badge size for README.md, px'
   dryrun:
     description: 'Generate badges, but skip pushing them to git'
   omit:
-    description: 'List of badges to exclude. For example, if you''re too shy to flex your stars: omit: stars-100,stars-500,stars-1000 or even shorter omit: stars-*'
+    description: >-
+      List of badges to exclude. For example, if you're too shy to flex your
+      stars: omit: stars-100,stars-500,stars-1000 or even shorter omit: stars-*
   pick:
-    desciption: 'list of badges to pick. Pass pick: a-commit,ab-commit,revert-revert-commit to generate only the specified entries. If empty gets all of them'
+    desciption: >-
+      list of badges to pick. Pass pick: a-commit,ab-commit,revert-revert-commit
+      to generate only the specified entries. If empty gets all of them
   compact:
-    description: 'Represent the highest tier badges in README.md. For example, If you have both stars-100 and stars-500 achievements, only the last one will be shown'
+    description: >-
+      Represent the highest tier badges in README.md. For example, If you have
+      both stars-100 and stars-500 achievements, only the last one will be shown
 runs:
-  using: "composite"
+  using: composite
   steps:
     - shell: bash
       run: npm install -g update-my-badges
     - shell: bash
-      run: >- 
-        update-my-badges --token ${{ inputs.token }} --user ${{ inputs.user }}
-        $([ "${{ inputs.repo }}" ]           && echo --repo "${{ inputs.repo }}")
-        $([ "${{ inputs.size }}" ]           && echo --size "${{ inputs.size }}")
+      run: >-
+        update-my-badges --token ${{ inputs.token }} --user ${{ inputs.user }
+        $([ "${{ inputs.repo }}" ]           && echo --repo "${{ inputs.repo}}")
+        $([ "${{ inputs.size }}" ]           && echo --size "${{inputs.size }}")
         $([ "${{ inputs.dryrun }}" = true ]  && echo --dryrun)
-        $([ "${{ inputs.omit }}" ]           && echo --omit "${{ inputs.omit }}")
+        $([ "${{ inputs.omit }}" ]           && echo --omit "${{ inputs.omit}}")
         $([ "${{ inputs.pick }}" ]           && echo --pick "${{ inputs.pick }}")
         $([ "${{ inputs.compact }}" = true ] && echo --compact)

--- a/action.yaml
+++ b/action.yaml
@@ -37,9 +37,9 @@ runs:
     - shell: bash
       run: >-
         update-my-badges --token ${{ inputs.token }} --user ${{ inputs.user }
-        $([ "${{ inputs.repo }}" ]           && echo --repo "${{ inputs.repo}}")
-        $([ "${{ inputs.size }}" ]           && echo --size "${{inputs.size }}")
+        $([ "${{ inputs.repo }}" ]           && echo --repo "${{ inputs.repo }}")
+        $([ "${{ inputs.size }}" ]           && echo --size "${{ inputs.size }}")
         $([ "${{ inputs.dryrun }}" = true ]  && echo --dryrun)
-        $([ "${{ inputs.omit }}" ]           && echo --omit "${{ inputs.omit}}")
+        $([ "${{ inputs.omit }}" ]           && echo --omit "${{ inputs.omit }}")
         $([ "${{ inputs.pick }}" ]           && echo --pick "${{ inputs.pick }}")
         $([ "${{ inputs.compact }}" = true ] && echo --compact)

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,39 @@
+name: 'My Badges'
+description: 'Generates My Badges'
+author: 'my-badges'
+branding:
+  icon: award
+  color: blue
+inputs:
+  token: 
+     description: 'Auth token' 
+     default: ${{ github.token }}
+  user:
+    description: 'Username' 
+    default: ${{ github.repository_owner }}
+  repo:
+    description: 'Repository name to push badges' 
+  size:
+    description: 'Badge size for README.md, px'
+  dryrun:
+    description: 'Generate badges, but skip pushing them to git'
+  omit:
+    description: 'List of badges to exclude. For example, if you''re too shy to flex your stars: omit: stars-100,stars-500,stars-1000 or even shorter omit: stars-*'
+  pick:
+    desciption: 'list of badges to pick. Pass pick: a-commit,ab-commit,revert-revert-commit to generate only the specified entries. If empty gets all of them'
+  compact:
+    description: 'Represent the highest tier badges in README.md. For example, If you have both stars-100 and stars-500 achievements, only the last one will be shown'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: npm install -g update-my-badges
+    - shell: bash
+      run: >- 
+        update-my-badges --token ${{ inputs.token }} --user ${{ inputs.user }}
+        $([ "${{ inputs.repo }}" ]           && echo --repo "${{ inputs.repo }}")
+        $([ "${{ inputs.size }}" ]           && echo --size "${{ inputs.size }}")
+        $([ "${{ inputs.dryrun }}" = true ]  && echo --dryrun)
+        $([ "${{ inputs.omit }}" ]           && echo --omit "${{ inputs.omit }}")
+        $([ "${{ inputs.pick }}" ]           && echo --pick "${{ inputs.pick }}")
+        $([ "${{ inputs.compact }}" = true ] && echo --compact)


### PR DESCRIPTION
This PR will add a GitHub Action meta file to simplify usage of **my badges** in GitHub Actions workflows. e.g.
```yaml
permissions: 
  contents: write
jobs:
  generate-badges:
    runs-on: ubuntu-latest
    steps:
       - uses: my-badges/my-badges@master
```