### PR TITLE
Add support for guessing Boston/MA timezones

### DIFF
--- a/badges/time-of-commit/time-of-commit.ts
+++ b/badges/time-of-commit/time-of-commit.ts
@@ -74,6 +74,7 @@ function guessTimezone(user: User) {
     { pattern: /\bberlin\b|\bgermany\b/, offset: 2 },
     { pattern: /\bbilbao\b|\bzaragoza\b/, offset: 2 },
     { pattern: /\bbordeaux\b|\bmarseille\b|\blyon\b/, offset: 2 },
+    { pattern: /\bboston\b|\bmassachusetts\b|\bma\b/, offset: -4 },
     { pattern: /\bbratislava\b|\bslovakia\b/, offset: 2 },
     { pattern: /\bbrazil\b|\bsao paulo\b|\brio de janeiro\b/, offset: -3 },
     { pattern: /\bbrussels\b|\bbelgium\b/, offset: 2 },


### PR DESCRIPTION
Adding support for detecting timezone for locations containing Boston/Massachusetts/MA

I also started a discussion to request timezone support in the GitHub REST API, as users can declare their timezone offset in their profile: https://github.com/orgs/community/discussions/146633