### PR TITLE
bug: opensource-library-night-24 badge message must be in html

### DIFF
--- a/badges/oss-library-night-24/oss-library-night-24.ts
+++ b/badges/oss-library-night-24/oss-library-night-24.ts
@@ -49,7 +49,7 @@ export default define({
     if (pulls.length > 0) {
       grant(
         'oss-library-night-24',
-        "I've participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!",
+        'I\'ve participated in the <a href="https://events.yandex.ru/events/opensourcenight">Opensource Library Night 24</a>!',
       ).evidencePRs(...pulls)
     }
   },


### PR DESCRIPTION
Parent badge template wraps the badge message in HTML code. Therefore Markdown URL breaks the formatting. This tiny change should fix it.