### PR TITLE
bug: allow html tags in badge description

### DIFF
--- a/badges/my-badges-contributor/my-badges-contributor.ts
+++ b/badges/my-badges-contributor/my-badges-contributor.ts
@@ -18,7 +18,7 @@ export default define({
     if (pulls.length > 0) {
       grant(
         'my-badges-contributor',
-        'I contributed to <https://github.com/my-badges/my-badges>!',
+        'I contributed to [my-badges](https://github.com/my-badges/my-badges)!',
       ).evidencePRs(...pulls)
     }
   },

--- a/badges/oss-library-night-24/oss-library-night-24.ts
+++ b/badges/oss-library-night-24/oss-library-night-24.ts
@@ -49,7 +49,7 @@ export default define({
     if (pulls.length > 0) {
       grant(
         'oss-library-night-24',
-        'I\'ve participated in the <a href="https://events.yandex.ru/events/opensourcenight">Opensource Library Night 24</a>!',
+        'I\'ve participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!',
       ).evidencePRs(...pulls)
     }
   },

--- a/badges/oss-library-night-24/oss-library-night-24.ts
+++ b/badges/oss-library-night-24/oss-library-night-24.ts
@@ -49,7 +49,7 @@ export default define({
     if (pulls.length > 0) {
       grant(
         'oss-library-night-24',
-        'I\'ve participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!',
+        "I've participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!",
       ).evidencePRs(...pulls)
     }
   },

--- a/src/update-badges.ts
+++ b/src/update-badges.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { Badge } from './badges.js'
-import { quoteAttr } from './utils.js'
+import { quoteAttr, stripMarkdown } from './utils.js'
 import { log } from './log.js'
 
 export function updateBadges(
@@ -15,7 +15,7 @@ export function updateBadges(
 
   for (const badge of badges) {
     const badgePath = path.resolve(badgesDir, `${badge.id}.md`)
-    const desc = quoteAttr(badge.desc)
+    const desc = stripMarkdown(badge.desc)
     const content =
       `<img src="${badge.image}" alt="${desc}" title="${desc}" width="128">\n\n` +
       `**${badge.desc}**\n\n` +

--- a/src/update-badges.ts
+++ b/src/update-badges.ts
@@ -18,7 +18,7 @@ export function updateBadges(
     const desc = quoteAttr(badge.desc)
     const content =
       `<img src="${badge.image}" alt="${desc}" title="${desc}" width="128">\n` +
-      `<strong>${desc}</strong>\n` +
+      `<strong>${badge.desc}</strong>\n` +
       `<br><br>\n\n` +
       badge.body +
       `\n\n\n` +

--- a/src/update-badges.ts
+++ b/src/update-badges.ts
@@ -17,12 +17,11 @@ export function updateBadges(
     const badgePath = path.resolve(badgesDir, `${badge.id}.md`)
     const desc = quoteAttr(badge.desc)
     const content =
-      `<img src="${badge.image}" alt="${desc}" title="${desc}" width="128">\n` +
-      `<strong>${badge.desc}</strong>\n` +
-      `<br><br>\n\n` +
+      `<img src="${badge.image}" alt="${desc}" title="${desc}" width="128">\n\n` +
+      `**${badge.desc}**\n\n` +
       badge.body +
       `\n\n\n` +
-      `Created by <a href="https://github.com/my-badges/my-badges">My Badges</a>`
+      `Created by <a href="https://github.com/my-badges/my-badges">My 2 Badges</a>`
 
     log.info('badge', badgePath)
     fs.writeFileSync(badgePath, content)

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "vitest";
+import { stripMarkdown, quoteAttr } from './utils.js'
+
+describe('utils', () => {
+    test('quoteAttr() should escape special characters', async () => {
+        const cases = [
+            { s: "", want: "" },
+            { s: "abc", want: "abc" },
+            { s: "&'\"<>", want: "&amp;&apos;&quot;&lt;&gt;" },
+            { s: "\r\n", want: "&#13;" },
+            { s: "\n\n\r\r", want: "&#13;&#13;&#13;&#13;" },
+        ]
+
+        cases.forEach(function (c) {
+            expect(quoteAttr(c.s)).toBe(c.want)
+        })
+    })
+
+    test('stripMarkdown() should strip markdown to plain text', async () => {
+        const cases = [
+            { s: "hello", want: "hello" },
+            { s: "**hello**", want: "**hello**" },
+            { s: "[github](https://github.com)", want: "github" },
+            { s: "hello, [github](https://github.com?token=(*?))!]", want: "hello, github!]" },
+        ]
+
+        cases.forEach(function (c) {
+            expect(stripMarkdown(c.s)).toBe(c.want)
+        })
+    })
+})

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,31 +1,34 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect } from 'vitest'
 import { stripMarkdown, quoteAttr } from './utils.js'
 
 describe('utils', () => {
-    test('quoteAttr() should escape special characters', async () => {
-        const cases = [
-            { s: "", want: "" },
-            { s: "abc", want: "abc" },
-            { s: "&'\"<>", want: "&amp;&apos;&quot;&lt;&gt;" },
-            { s: "\r\n", want: "&#13;" },
-            { s: "\n\n\r\r", want: "&#13;&#13;&#13;&#13;" },
-        ]
+  test('quoteAttr() should escape special characters', async () => {
+    const cases = [
+      { s: '', want: '' },
+      { s: 'abc', want: 'abc' },
+      { s: '&\'"<>', want: '&amp;&apos;&quot;&lt;&gt;' },
+      { s: '\r\n', want: '&#13;' },
+      { s: '\n\n\r\r', want: '&#13;&#13;&#13;&#13;' },
+    ]
 
-        cases.forEach(function (c) {
-            expect(quoteAttr(c.s)).toBe(c.want)
-        })
+    cases.forEach(function (c) {
+      expect(quoteAttr(c.s)).toBe(c.want)
     })
+  })
 
-    test('stripMarkdown() should strip markdown to plain text', async () => {
-        const cases = [
-            { s: "hello", want: "hello" },
-            { s: "**hello**", want: "**hello**" },
-            { s: "[github](https://github.com)", want: "github" },
-            { s: "hello, [github](https://github.com?token=(*?))!]", want: "hello, github!]" },
-        ]
+  test('stripMarkdown() should strip markdown to plain text', async () => {
+    const cases = [
+      { s: 'hello', want: 'hello' },
+      { s: '**hello**', want: '**hello**' },
+      { s: '[github](https://github.com)', want: 'github' },
+      {
+        s: 'hello, [github](https://github.com?token=(*?))!]',
+        want: 'hello, github!]',
+      },
+    ]
 
-        cases.forEach(function (c) {
-            expect(stripMarkdown(c.s)).toBe(c.want)
-        })
+    cases.forEach(function (c) {
+      expect(stripMarkdown(c.s)).toBe(c.want)
     })
+  })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,15 +81,15 @@ export function quoteAttr(s: string) {
 }
 
 type Pattern = {
-  pattern: RegExp,
+  pattern: RegExp
   replace: string
 }
 
 export function stripMarkdown(
   text: string,
   patterns: Pattern[] = [
-    { pattern: /\[([^\r\n]+)\]\([^\r\n]+\)/g, replace: "$1" } // strip all markdown urls
-  ]
+    { pattern: /\[([^\r\n]+)\]\([^\r\n]+\)/g, replace: '$1' }, // strip all markdown urls
+  ],
 ): string {
   return patterns.reduce((t, p) => {
     return t.replace(p.pattern, p.replace)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,6 +80,22 @@ export function quoteAttr(s: string) {
     .replace(/[\r\n]/g, '&#13;')
 }
 
+type Pattern = {
+  pattern: RegExp,
+  replace: string
+}
+
+export function stripMarkdown(
+  text: string,
+  patterns: Pattern[] = [
+    { pattern: /\[([^\r\n]+)\]\([^\r\n]+\)/g, replace: "$1" } // strip all markdown urls
+  ]
+): string {
+  return patterns.reduce((t, p) => {
+    return t.replace(p.pattern, p.replace)
+  }, text)
+}
+
 export function parseMask(value: string): RegExp {
   return new RegExp(`^${value}$`.replace('*', '.+'))
 }


### PR DESCRIPTION
This change fixes the issue where HTML tags were unexpectedly escaped in [some badge descriptions](https://github.com/1e9y/1e9y/blob/main/my-badges/oss-library-night-24.md). 

Example of the new output:

<img src="https://my-badges.github.io/my-badges/oss-library-night-24.png" alt="I&apos;ve participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!" title="I&apos;ve participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!" width="128">

**I've participated in the [Opensource Library Night 24](https://events.yandex.ru/events/opensourcenight)!**

Question:

* Do we still want the markdown or any other complex layouting in `alt` or `title` attributes?