### PR TITLE
feat(favorite-word): ignore conventional commit

### DIFF
--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -122,10 +122,13 @@ describe('favorite-word', () => {
           CommitFactory(`${prefix}!: world hello`, ''),
           CommitFactory('hello', `${prefix}: `),
         ])
+        let badge: Badge = { id: 'favorite-word', desc: '', body: '', image: '', tier: 0 }
         favoriteWord.present(data, (id: "favorite-word", desc: string) => {
           expect(desc).toBe(`My favorite word is "hello".`)
           return new Evidence(badge)
         })
+        const prefixExpectation = (prefix + ':').toLowerCase().split(' ').map((word, i) => `${i + 3}. ${word} (used once)`).join('\n')
+        expect(badge.body).toBe(`My favorite commit message words are:\n\n1. hello (used 5 times)\n2. world (used 3 times)\n${prefixExpectation}`)
       })
     }
   })

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -1,14 +1,12 @@
-import { describe, it, expect, afterAll } from 'vitest'
-import fs from 'node:fs/promises'
+import { describe, it, expect } from 'vitest'
 import favoriteWord from './favorite-word.js'
-import os from 'node:os'
-import { log } from '../../src/log.js'
-import { Badge } from '../../src/badges.js'
 import { Data } from '../../src/data.js'
+import { Badge } from '../../src/badges.js'
 import { Commit } from '../../src/task/commits/commits.graphql.js'
+import { Evidence } from '../../src/badges.js'
 
 function CommitFactory(message: string, messageBody: string) {
-  const commit: Commit = {
+  return {
     message,
     messageBody,
     id: '',
@@ -24,12 +22,11 @@ function CommitFactory(message: string, messageBody: string) {
       },
       name: '',
     },
-  }
-  return commit
+  } as Commit
 }
 
 function DataFactory(commits: Commit[]) {
-  const data: Data = {
+  return {
     repos: [
       {
         commits,
@@ -96,8 +93,7 @@ function DataFactory(commits: Commit[]) {
         nodes: null
       },
     }
-  }
-  return data
+  } as Data
 }
 
 describe.skip('favorite-word', () => {

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -98,6 +98,27 @@ function DataFactory(commits: Commit[]) {
 
 describe.skip('favorite-word', () => {
   // prettier-ignore
-  describe('ignore conventional commit prefixes', () => {})
+  describe('ignore conventional commit prefixes', () => {
+    const prefixes = [
+      'BREAKING CHANGE',
+      'build',
+      'chore',
+      'ci',
+      'docs',
+      'feat',
+      'fix',
+      'perf',
+      'refactor',
+      'revert',
+      'style',
+      'test',
+    ]
+    const data: Data = DataFactory([
+      CommitFactory(`${prefix}: hello`, ''),
+      CommitFactory(`${prefix}: hello world`, ''),
+      CommitFactory(`${prefix}:world hello`, ''),
+      CommitFactory(`${prefix}! :world hello`, ''),
+      CommitFactory('hello', `${prefix}: `),
+    ])
+  })
 })
-

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -96,7 +96,7 @@ function DataFactory(commits: Commit[]) {
   } as Data
 }
 
-describe.skip('favorite-word', () => {
+describe('favorite-word', () => {
   // prettier-ignore
   describe('ignore conventional commit prefixes', () => {
     const prefixes = [
@@ -113,12 +113,20 @@ describe.skip('favorite-word', () => {
       'style',
       'test',
     ]
-    const data: Data = DataFactory([
-      CommitFactory(`${prefix}: hello`, ''),
-      CommitFactory(`${prefix}: hello world`, ''),
-      CommitFactory(`${prefix}:world hello`, ''),
-      CommitFactory(`${prefix}! :world hello`, ''),
-      CommitFactory('hello', `${prefix}: `),
-    ])
+    for (const prefix of prefixes) {
+      it(`ignores "${prefix}"`, () => {
+        const data: Data = DataFactory([
+          CommitFactory(`${prefix}(world): hello`, ''),
+          CommitFactory(`${prefix}: hello world`, ''),
+          CommitFactory(`${prefix}:world hello`, ''),
+          CommitFactory(`${prefix}!: world hello`, ''),
+          CommitFactory('hello', `${prefix}: `),
+        ])
+        favoriteWord.present(data, (id: "favorite-word", desc: string) => {
+          expect(desc).toBe(`My favorite word is "hello".`)
+          return new Evidence(badge)
+        })
+      })
+    }
   })
 })

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -5,6 +5,100 @@ import os from 'node:os'
 import { log } from '../../src/log.js'
 import { Badge } from '../../src/badges.js'
 import { Data } from '../../src/data.js'
+import { Commit } from '../../src/task/commits/commits.graphql.js'
+
+function CommitFactory(message: string, messageBody: string) {
+  const commit: Commit = {
+    message,
+    messageBody,
+    id: '',
+    sha: '',
+    committedDate: '',
+    additions: 0,
+    deletions: 0,
+    author: null,
+    committer: null,
+    repository: {
+      owner: {
+      login: '',
+      },
+      name: '',
+    },
+  }
+  return commit
+}
+
+function DataFactory(commits: Commit[]) {
+  const data: Data = {
+    repos: [
+      {
+        commits,
+        id: '',
+        name: '',
+        owner: {
+        login: '',
+        },
+        url: '',
+        description: null,
+        createdAt: '',
+        updatedAt: '',
+        languages: null,
+        forks: {
+        totalCount: 0,
+        },
+        stargazers: {
+        totalCount: 0,
+        },
+        defaultBranchRef: null,
+        isEmpty: false,
+      },
+    ],
+    starredRepositories: [],
+    pulls: [],
+    issues: [],
+    issueComments: [],
+    discussionComments: [],
+    user: {
+      id: '',
+      login: '',
+      name: '',
+      avatarUrl: '',
+      bio: '',
+      company: '',
+      location: '',
+      email: '',
+      twitterUsername: null,
+      websiteUrl: null,
+      status: null,
+      createdAt: '',
+      followers: {
+        totalCount: 0,
+      },
+      following: {
+        totalCount: 0,
+      },
+      anyPinnableItems: false,
+      pinnedItems: {
+        totalCount: 0,
+        nodes: null
+      },
+      sponsoring: {
+        totalCount: 0,
+      },
+      sponsors: {
+        totalCount: 0,
+      },
+      starredRepositories: {
+        totalCount: 0,
+      },
+      publicKeys: {
+        totalCount: 0,
+        nodes: null
+      },
+    }
+  }
+  return data
+}
 
 describe.skip('favorite-word', () => {
   // prettier-ignore

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -1,100 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import favoriteWord from './favorite-word.js'
-import { Data } from '../../src/data.js'
-import { Badge } from '../../src/badges.js'
-import { Commit } from '../../src/task/commits/commits.graphql.js'
-import { Evidence } from '../../src/badges.js'
-
-function CommitFactory(message: string, messageBody: string) {
-  return {
-    message,
-    messageBody,
-    id: '',
-    sha: '',
-    committedDate: '',
-    additions: 0,
-    deletions: 0,
-    author: null,
-    committer: null,
-    repository: {
-      owner: {
-        login: '',
-      },
-      name: '',
-    },
-  } as Commit
-}
-
-function DataFactory(commits: Commit[]) {
-  return {
-    repos: [
-      {
-        commits,
-        id: '',
-        name: '',
-        owner: {
-          login: '',
-        },
-        url: '',
-        description: null,
-        createdAt: '',
-        updatedAt: '',
-        languages: null,
-        forks: {
-          totalCount: 0,
-        },
-        stargazers: {
-          totalCount: 0,
-        },
-        defaultBranchRef: null,
-        isEmpty: false,
-      },
-    ],
-    starredRepositories: [],
-    pulls: [],
-    issues: [],
-    issueComments: [],
-    discussionComments: [],
-    user: {
-      id: '',
-      login: '',
-      name: '',
-      avatarUrl: '',
-      bio: '',
-      company: '',
-      location: '',
-      email: '',
-      twitterUsername: null,
-      websiteUrl: null,
-      status: null,
-      createdAt: '',
-      followers: {
-        totalCount: 0,
-      },
-      following: {
-        totalCount: 0,
-      },
-      anyPinnableItems: false,
-      pinnedItems: {
-        totalCount: 0,
-        nodes: null,
-      },
-      sponsoring: {
-        totalCount: 0,
-      },
-      sponsors: {
-        totalCount: 0,
-      },
-      starredRepositories: {
-        totalCount: 0,
-      },
-      publicKeys: {
-        totalCount: 0,
-        nodes: null,
-      },
-    },
-  } as Data
-}
+import { splitWithoutTooFrequentWords } from './favorite-word.js'
 
 describe('favorite-word', () => {
   // prettier-ignore
@@ -114,22 +19,28 @@ describe('favorite-word', () => {
       'test',
     ]
     for (const prefix of prefixes) {
-      it(`ignores "${prefix}"`, () => {
-        const data: Data = DataFactory([
-          CommitFactory(`${prefix}(world): hello`, ''),
-          CommitFactory(`${prefix}: hello world`, ''),
-          CommitFactory(`${prefix}:world hello`, ''),
-          CommitFactory(`${prefix}!: world hello`, ''),
-          CommitFactory('hello', `${prefix}: `),
-        ])
-        let badge: Badge = { id: 'favorite-word', desc: '', body: '', image: '', tier: 0 }
-        favoriteWord.present(data, (id: "favorite-word", desc: string) => {
-          expect(desc).toBe(`My favorite word is "hello".`)
-          return new Evidence(badge)
+	  describe(`"${prefix}"`, () => {
+        it(`ignores "${prefix}" at the beginning of the message`, () => {
+          expect(splitWithoutTooFrequentWords(`${prefix}: hello world`)).toEqual(['hello', 'world'])
         })
-        const prefixExpectation = (prefix + ':').toLowerCase().split(' ').map((word, i) => `${i + 3}. ${word} (used once)`).join('\n')
-        expect(badge.body).toBe(`My favorite commit message words are:\n\n1. hello (used 5 times)\n2. world (used 3 times)\n${prefixExpectation}`)
-      })
+        it(`ignores "${prefix}" without space after it`, () => {
+          expect(splitWithoutTooFrequentWords(`${prefix}:hello world`)).toEqual(['hello', 'world'])
+        })
+        it(`ignores "${prefix}" with exclamation mark`, () => {
+          expect(splitWithoutTooFrequentWords(`${prefix}!: hello world`)).toEqual(['hello', 'world'])
+        })
+        it(`ignores "${prefix}" with scope`, () => {
+          expect(splitWithoutTooFrequentWords(`${prefix}(world): hello`)).toEqual(['hello'])
+        })
+        it(`don't ignore "${prefix}" if not at the beginning`, () => {
+	      const expectedPrefix = `${prefix}:`.toLowerCase().split(' ')
+	      expectedPrefix.unshift('hello')
+          expect(splitWithoutTooFrequentWords(`hello ${prefix}:`)).toEqual(expectedPrefix)
+        })
+	  })
     }
+    it(`don't ignore fake prefix`, () => {
+      expect(splitWithoutTooFrequentWords(`fake: hello world`)).toEqual(['fake:', 'hello', 'world'])
+    })
   })
 })

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import fs from 'node:fs/promises'
+import favoriteWord from './favorite-word.js'
+import os from 'node:os'
+import { log } from '../../src/log.js'
+import { Badge } from '../../src/badges.js'
+import { Data } from '../../src/data.js'
+
+describe.skip('favorite-word', () => {
+  // prettier-ignore
+  describe('ignore conventional commit prefixes', () => {})
+})
+

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -18,7 +18,7 @@ function CommitFactory(message: string, messageBody: string) {
     committer: null,
     repository: {
       owner: {
-      login: '',
+        login: '',
       },
       name: '',
     },
@@ -33,7 +33,7 @@ function DataFactory(commits: Commit[]) {
         id: '',
         name: '',
         owner: {
-        login: '',
+          login: '',
         },
         url: '',
         description: null,
@@ -41,10 +41,10 @@ function DataFactory(commits: Commit[]) {
         updatedAt: '',
         languages: null,
         forks: {
-        totalCount: 0,
+          totalCount: 0,
         },
         stargazers: {
-        totalCount: 0,
+          totalCount: 0,
         },
         defaultBranchRef: null,
         isEmpty: false,
@@ -77,7 +77,7 @@ function DataFactory(commits: Commit[]) {
       anyPinnableItems: false,
       pinnedItems: {
         totalCount: 0,
-        nodes: null
+        nodes: null,
       },
       sponsoring: {
         totalCount: 0,
@@ -90,9 +90,9 @@ function DataFactory(commits: Commit[]) {
       },
       publicKeys: {
         totalCount: 0,
-        nodes: null
+        nodes: null,
       },
-    }
+    },
   } as Data
 }
 

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -9,18 +9,7 @@ export default define({
     for (const repo of data.repos) {
       for (const commit of repo.commits) {
         const msg = commit.message + '\n' + commit.messageBody
-        const words = removeStopwords(
-          msg
-            .toLowerCase()
-            // remove conventional commit prefixes as they would outweigh other words
-            .replace(
-              /^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?:\s*/,
-              '',
-            )
-            .split(/\s+/)
-            // ignore words not including alphanumeric chars
-            .filter((w) => /\w/.test(w)),
-        )
+        const words = splitWithoutTooFrequentWords(msg)
         for (const word of words) {
           counts[word] = (counts[word] || 0) + 1
         }
@@ -41,3 +30,18 @@ export default define({
     )
   },
 })
+
+export function splitWithoutTooFrequentWords(msg: string) {
+  return removeStopwords(
+    msg
+      .toLowerCase()
+      // remove conventional commit prefixes as they would outweigh other words
+      .replace(
+        /^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?:\s*/,
+        '',
+      )
+      .split(/\s+/)
+      // ignore words not including alphanumeric chars
+      .filter((w) => /\w/.test(w)),
+  )
+}

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -13,7 +13,10 @@ export default define({
           msg
             .toLowerCase()
             // remove conventional commit prefixes as they would outweigh other words
-            .replace(/^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?:\s*/, '')
+            .replace(
+              /^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?:\s*/,
+              '',
+            )
             .split(/\s+/)
             // ignore words not including alphanumeric chars
             .filter((w) => /\w/.test(w)),

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -12,6 +12,8 @@ export default define({
         const words = removeStopwords(
           msg
             .toLowerCase()
+            // remove conventional commit prefixes as they would outweigh other words
+            .replace(/^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?:\s+/, '')
             .split(/\s+/)
             // ignore words not including alphanumeric chars
             .filter((w) => /\w/.test(w)),

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -13,7 +13,7 @@ export default define({
           msg
             .toLowerCase()
             // remove conventional commit prefixes as they would outweigh other words
-            .replace(/^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?:\s+/, '')
+            .replace(/^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!?:\s+/, '')
             .split(/\s+/)
             // ignore words not including alphanumeric chars
             .filter((w) => /\w/.test(w)),

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -13,7 +13,7 @@ export default define({
           msg
             .toLowerCase()
             // remove conventional commit prefixes as they would outweigh other words
-            .replace(/^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!?:\s+/, '')
+            .replace(/^(breaking change|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.*\))?!?:\s*/, '')
             .split(/\s+/)
             // ignore words not including alphanumeric chars
             .filter((w) => /\w/.test(w)),


### PR DESCRIPTION
People using [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) are putting them at the beginning every single commit, because of that, words like `feat:` and `fix:` are way more frequent than most other words which also makes them not really interesting for the favorite word badge

![image](https://github.com/user-attachments/assets/2ebec61b-89c7-4077-95c4-4cefb52828c8)