### PR TITLE
Add support for `.github`-based profiles

### DIFF
--- a/src/update-readme.ts
+++ b/src/update-readme.ts
@@ -21,7 +21,7 @@ export function updateReadme(
 }
 
 function detectReadmeFilename(cwd: string): string {
-  const file = ['README.md', 'readme.md']
+  const file = ['README.md', 'readme.md', 'profile/README.md', 'profile/readme.md']
     .map((f) => path.resolve(cwd, f))
     .find((f) => fs.existsSync(f))
   if (!file) throw new Error('Cannot find README.md')


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature


## What is the current behavior? (You can also link to an open issue here)
My Badges does not support `{user}/.github` repositories.


## What is the new behavior (if this is a feature change)?
My Badges supports `{user}/.github` repositories.


## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No


## Other information
`{user}/{user}` is one of two "special repositories", the other is `{user}/.github`. Unfortunately, 'My Badges' only supports the first.
There's no official documentation available, but see this screenshot:

<img width="1343" height="339" alt="Bildschirmfoto 2026-01-22 um 08 05 41" src="https://github.com/user-attachments/assets/b0d574b0-308d-4b82-9e5c-efd8ac5fede7" />

(I renamed that repository from `{user}/{user}` to `{user}/.github`; that's why it already includes badges.)

Note that this change is untested.