### PR TITLE
filter commit signature messages and other similar trailers

### DIFF
--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -46,31 +46,49 @@ describe('favorite-word', () => {
 
   describe('ignore git trailer lines', () => {
     it('ignores Signed-off-by lines', () => {
-      expect(splitWithoutTooFrequentWords('hello world\n\nSigned-off-by: Jane Doe <jane@example.com>')).toEqual(['hello', 'world'])
+      expect(
+        splitWithoutTooFrequentWords(
+          'hello world\n\nSigned-off-by: Jane Doe <jane@example.com>',
+        ),
+      ).toEqual(['hello', 'world'])
     })
     it('ignores Co-authored-by lines', () => {
-      expect(splitWithoutTooFrequentWords('hello world\n\nCo-authored-by: Jane Doe <jane@example.com>')).toEqual(['hello', 'world'])
+      expect(
+        splitWithoutTooFrequentWords(
+          'hello world\n\nCo-authored-by: Jane Doe <jane@example.com>',
+        ),
+      ).toEqual(['hello', 'world'])
     })
     it('does not ignore non-trailer lines', () => {
-      expect(splitWithoutTooFrequentWords('hello world\nsome-token: not a trailer')).toEqual(['hello', 'world', 'some-token:', 'not', 'trailer'])
+      expect(
+        splitWithoutTooFrequentWords('hello world\nsome-token: not a trailer'),
+      ).toEqual(['hello', 'world', 'some-token:', 'not', 'trailer'])
     })
   })
 
   describe('ignore email addresses', () => {
     it('ignores angle-bracket email tokens', () => {
-      expect(splitWithoutTooFrequentWords('hello <jane@example.com> world')).toEqual(['hello', 'world'])
+      expect(
+        splitWithoutTooFrequentWords('hello <jane@example.com> world'),
+      ).toEqual(['hello', 'world'])
     })
     it('ignores bare email tokens', () => {
-      expect(splitWithoutTooFrequentWords('hello jane@example.com world')).toEqual(['hello', 'world'])
+      expect(
+        splitWithoutTooFrequentWords('hello jane@example.com world'),
+      ).toEqual(['hello', 'world'])
     })
   })
 
   describe('ignore excluded words', () => {
     it('ignores words in the exclude list', () => {
-      expect(splitWithoutTooFrequentWords('hello jane world', ['jane'])).toEqual(['hello', 'world'])
+      expect(
+        splitWithoutTooFrequentWords('hello jane world', ['jane']),
+      ).toEqual(['hello', 'world'])
     })
     it('exclude list is case-insensitive', () => {
-      expect(splitWithoutTooFrequentWords('hello Jane world', ['jane'])).toEqual(['hello', 'world'])
+      expect(
+        splitWithoutTooFrequentWords('hello Jane world', ['jane']),
+      ).toEqual(['hello', 'world'])
     })
   })
 })

--- a/badges/favorite-word/favorite-word.test.ts
+++ b/badges/favorite-word/favorite-word.test.ts
@@ -43,4 +43,34 @@ describe('favorite-word', () => {
       expect(splitWithoutTooFrequentWords(`fake: hello world`)).toEqual(['fake:', 'hello', 'world'])
     })
   })
+
+  describe('ignore git trailer lines', () => {
+    it('ignores Signed-off-by lines', () => {
+      expect(splitWithoutTooFrequentWords('hello world\n\nSigned-off-by: Jane Doe <jane@example.com>')).toEqual(['hello', 'world'])
+    })
+    it('ignores Co-authored-by lines', () => {
+      expect(splitWithoutTooFrequentWords('hello world\n\nCo-authored-by: Jane Doe <jane@example.com>')).toEqual(['hello', 'world'])
+    })
+    it('does not ignore non-trailer lines', () => {
+      expect(splitWithoutTooFrequentWords('hello world\nsome-token: not a trailer')).toEqual(['hello', 'world', 'some-token:', 'not', 'trailer'])
+    })
+  })
+
+  describe('ignore email addresses', () => {
+    it('ignores angle-bracket email tokens', () => {
+      expect(splitWithoutTooFrequentWords('hello <jane@example.com> world')).toEqual(['hello', 'world'])
+    })
+    it('ignores bare email tokens', () => {
+      expect(splitWithoutTooFrequentWords('hello jane@example.com world')).toEqual(['hello', 'world'])
+    })
+  })
+
+  describe('ignore excluded words', () => {
+    it('ignores words in the exclude list', () => {
+      expect(splitWithoutTooFrequentWords('hello jane world', ['jane'])).toEqual(['hello', 'world'])
+    })
+    it('exclude list is case-insensitive', () => {
+      expect(splitWithoutTooFrequentWords('hello Jane world', ['jane'])).toEqual(['hello', 'world'])
+    })
+  })
 })

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -5,11 +5,16 @@ export default define({
   url: import.meta.url,
   badges: ['favorite-word'] as const,
   present(data, grant) {
+    const userWords = [
+      data.user.login,
+      ...(data.user.name ? data.user.name.split(/\s+/) : []),
+    ].map((w) => w.toLowerCase())
+
     const counts: Record<string, number> = {}
     for (const repo of data.repos) {
       for (const commit of repo.commits) {
         const msg = commit.message + '\n' + commit.messageBody
-        const words = splitWithoutTooFrequentWords(msg)
+        const words = splitWithoutTooFrequentWords(msg, userWords)
         for (const word of words) {
           counts[word] = (counts[word] || 0) + 1
         }
@@ -31,10 +36,16 @@ export default define({
   },
 })
 
-export function splitWithoutTooFrequentWords(msg: string) {
+export function splitWithoutTooFrequentWords(msg: string, exclude: string[] = []) {
+  const excludeSet = new Set(exclude.map((w) => w.toLowerCase()))
   return removeStopwords(
     msg
       .toLowerCase()
+      // remove git commit trailer lines (Signed-off-by:, Co-authored-by:, etc.)
+      .replace(
+        /^(signed-off-by|co-authored-by|reviewed-by|acked-by|tested-by|reported-by):[ \t].+$/gm,
+        '',
+      )
       // remove conventional commit prefixes as they would outweigh other words
       .replace(
         /^(breaking changes?|build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\(.*?\))?!?:/gm,
@@ -42,6 +53,10 @@ export function splitWithoutTooFrequentWords(msg: string) {
       )
       .split(/\s+/)
       // ignore words not including alphanumeric chars
-      .filter((w) => /\w/.test(w)),
+      .filter((w) => /\w/.test(w))
+      // ignore email addresses and angle-bracket tokens
+      .filter((w) => !/@/.test(w) && !/^<.*>$/.test(w))
+      // ignore user-provided words (e.g. the committer's own name and login)
+      .filter((w) => !excludeSet.has(w)),
   )
 }

--- a/badges/favorite-word/favorite-word.ts
+++ b/badges/favorite-word/favorite-word.ts
@@ -36,7 +36,10 @@ export default define({
   },
 })
 
-export function splitWithoutTooFrequentWords(msg: string, exclude: string[] = []) {
+export function splitWithoutTooFrequentWords(
+  msg: string,
+  exclude: string[] = [],
+) {
   const excludeSet = new Set(exclude.map((w) => w.toLowerCase()))
   return removeStopwords(
     msg

--- a/src/update-readme.ts
+++ b/src/update-readme.ts
@@ -21,7 +21,12 @@ export function updateReadme(
 }
 
 function detectReadmeFilename(cwd: string): string {
-  const file = ['README.md', 'readme.md', 'profile/README.md', 'profile/readme.md']
+  const file = [
+    'README.md',
+    'readme.md',
+    'profile/README.md',
+    'profile/readme.md',
+  ]
     .map((f) => path.resolve(cwd, f))
     .find((f) => fs.existsSync(f))
   if (!file) throw new Error('Cannot find README.md')


### PR DESCRIPTION
My favorite words were, apparently, always Signed-off-by and my git user info and email address. This PR filters out these kinds of messages before doing the assessment of the most used words.